### PR TITLE
shim for missing invFlags

### DIFF
--- a/src/Commands/FlagShim.php
+++ b/src/Commands/FlagShim.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * User: Warlof Tutsimo <loic.leuilliot@gmail.com>
+ * Date: 29/12/2017
+ * Time: 19:51
+ */
+
+namespace Denngarr\Seat\SeatSrp\Commands;
+use Denngarr\Seat\SeatSrp\Models\Sde\InvFlag;
+
+
+use Illuminate\Console\Command;
+
+class FlagShim extends Command {
+
+    protected $signature = 'srp:glue:flag';
+
+    protected $description = 'Update the database with some flags not present in the SDE';
+
+    public function handle()
+    {
+        // Frigate Escape Bay
+        if(!InvFlag::where('flagID', 179)->exists()){
+            InvFlag::create([
+                'flagID' => 179,
+                'flagName' => 'FrigateBay',
+                'flagText' => 'Frigate Escape Bay',
+                'orderID' => 0
+            ])->save();
+        }
+
+        // Core room
+        if(!InvFlag::where('flagID', 180)->exists()){
+            InvFlag::create([
+                'flagID' => 180,
+                'flagName' => 'CoreRoom',
+                'flagText' => 'Core Room',
+                'orderID' => 0
+            ])->save();
+        }
+    }
+
+}

--- a/src/Config/srp.config.php
+++ b/src/Config/srp.config.php
@@ -5,5 +5,5 @@
  */
 
 return [
-    'version'   => '4.0.2'
+    'version'   => '4.0.3'
 ];

--- a/src/Models/Sde/InvFlag.php
+++ b/src/Models/Sde/InvFlag.php
@@ -16,6 +16,8 @@ class InvFlag extends Model {
 
     public $incrementing = false;
 
+    protected $fillable = ['flagID', 'flagName', 'flagText', 'orderID'];
+
     protected $table = 'invFlags';
 
     protected $primaryKey = 'flagID';

--- a/src/SrpServiceProvider.php
+++ b/src/SrpServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Denngarr\Seat\SeatSrp;
 
 use Denngarr\Seat\SeatSrp\Commands\InsuranceUpdate;
+use Denngarr\Seat\SeatSrp\Commands\FlagShim;
 use Seat\Services\AbstractSeatPlugin;
 
 class SrpServiceProvider extends AbstractSeatPlugin
@@ -80,6 +81,7 @@ class SrpServiceProvider extends AbstractSeatPlugin
     {
         $this->commands([
             InsuranceUpdate::class,
+            FlagShim::class,
         ]);
     }
 


### PR DESCRIPTION
Gives a command to populate missing invFlags entries. Only a shim until a better fix is available. 