### PR TITLE
bugfix for "stdclass property 'id' does not exist" / error on database migration 2020_03_01_231218_migrate_srp_version_four.php

### DIFF
--- a/src/database/migrations/2020_03_01_231218_migrate_srp_version_four.php
+++ b/src/database/migrations/2020_03_01_231218_migrate_srp_version_four.php
@@ -26,7 +26,7 @@ class MigrateSrpVersionFour extends Migration
                 ->first();
             if (is_null($new_id) || is_null($new_id->new_user_id)){
                 DB::table('seat_srp_srp')
-                    ->where('id', $entry->id)
+                    ->where('kill_id', $entry->kill_id)
                     ->delete();
                 continue;
             }


### PR DESCRIPTION
The db column "id" does not exist. The primary key column is named "kill_id". I renamed the field in the migration file.

Also: when you already tried the migration you have to delete/drop the backup table "seat_srp_srp_three", because the migration will try to create this table on every run of this migration.