### PR TITLE
Bunch o' Fixes

### DIFF
--- a/src/Http/Controllers/SrpAdminController.php
+++ b/src/Http/Controllers/SrpAdminController.php
@@ -7,23 +7,24 @@ use DB;
 use GuzzleHttp\Client;
 use Seat\Web\Http\Controllers\Controller;
 use Denngarr\Seat\SeatSrp\Models\KillMail;
-use Denngarr\Seat\SeatSrp\Validation\AddKillMail;
+use Denngarr\Seat\SeatSrp\Validation\AddReason;
 
 
-class SrpAdminController extends Controller {
+class SrpAdminController extends Controller
+{
 
     public function srpGetKillMails()
     {
-        $killmails = KillMail::where('approved','>','-2')->orderby('created_at', 'desc')->get();
+        $killmails = KillMail::where('approved', '>', '-2')->orderby('created_at', 'desc')->get();
 
         return view('srp::list', compact('killmails'));
     }
 
-    public function srpApprove($kill_id, $action) {
+    public function srpApprove($kill_id, $action)
+    {
         $killmail = KillMail::find($kill_id);
 
-        switch ($action)
-        {
+        switch ($action) {
             case 'Approve':
                 $killmail->approved = '1';
                 break;
@@ -40,8 +41,30 @@ class SrpAdminController extends Controller {
 
         $killmail->approver = auth()->user()->name;
         $killmail->save();
-        
+
         return json_encode(['name' => $action, 'value' => $kill_id, 'approver' => auth()->user()->name]);
     }
-}
 
+    public function srpAddReason(AddReason $request)
+    {
+
+        $kill_id = $request->input('srpKillId');
+
+        $killmail  = Killmail::find($kill_id);
+
+        
+
+        if (is_null($killmail))
+        return redirect()->back()
+            ->with('error', trans('srp::srp.not_found'));
+
+        $reason = $killmail->reason();
+        if (!is_null($reason)) 
+            $reason->delete();
+
+        KillMail::addNote($request->input('srpKillId'), 'reason', $request->input('srpReasonContent'));
+        
+        return redirect()->back()
+                         ->with('success', trans('srp::srp.note_updated'));
+    }
+}

--- a/src/Http/Controllers/SrpController.php
+++ b/src/Http/Controllers/SrpController.php
@@ -96,6 +96,19 @@ class SrpController extends Controller {
 			return response()->json($killmail->ping());
 
 		return response()->json(['msg' => sprintf('There are no ping information related to kill %s', $kill_id)], 204);
+    }
+    
+    public function getReason($kill_id)
+	{
+		$killmail = KillMail::find($kill_id);
+
+		if (is_null($killmail))
+			return response()->json(['msg' => sprintf('Unable to retrieve kill %s', $kill_id)], 404);
+
+		if (!is_null($killmail->reason()))
+			return response()->json($killmail->reason());
+
+		return response()->json(['msg' => sprintf('There are no reason information related to kill %s', $kill_id)], 204);
 	}
 
     private function srpPopulateSlots(stdClass $killMail) : array

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -87,6 +87,12 @@ Route::group([
             'middleware' => 'can:srp.settle'
         ]);
 
+        Route::post('/admin/addreason', [
+            'as'   => 'srp.addReason',
+            'uses' => 'SrpAdminController@srpAddReason',
+            'middleware' => 'can:srp.settle'
+        ]);
+
         Route::get('/admin/{kill_id}/{action}', [
             'as'   => 'srpadmin.settle',
             'uses' => 'SrpAdminController@srpApprove',
@@ -102,6 +108,12 @@ Route::group([
         Route::get('/ping/{kill_id}', [
         	'as' => 'srp.ping',
 	        'uses' => 'SrpController@getPing',
+	        'middleware' => 'can:srp.request',
+        ]);
+
+        Route::get('/reason/{kill_id}', [
+        	'as' => 'srp.reason',
+	        'uses' => 'SrpController@getReason',
 	        'middleware' => 'can:srp.request',
         ]);
 

--- a/src/Validation/AddReason.php
+++ b/src/Validation/AddReason.php
@@ -1,0 +1,23 @@
+<?PHP
+
+namespace Denngarr\Seat\SeatSrp\Validation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddReason extends FormRequest
+{
+
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'srpKillId' => 'exists:seat_srp_srp,kill_id|required|integer',
+            'srpReasonContent' => 'nullable|string'
+        ];
+    }
+}
+

--- a/src/resources/views/includes/reason-edit-modal.blade.php
+++ b/src/resources/views/includes/reason-edit-modal.blade.php
@@ -1,0 +1,24 @@
+<div class="modal fade" tabindex="-1" role="dialog" id="srp-reason-edit">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Reason</h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form role="form" action="{{ route('srp.addReason') }}" method="post">
+
+                    <div class="form-group">
+                        <label for="srpPingContent">Reason</label>
+                        <input id="reasonContent" class="form-control" name="srpReasonContent" rows="3" placeholder="Reason"></textarea>
+                    </div>
+                    <input type="hidden" class="form-control" id="srpKillId" name="srpKillId" value="0" />
+                    {{ csrf_field() }}
+                    <input type="submit" class="btn btn-primary" id="saveReasson" value="Save Reason" />
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/resources/views/includes/reason-modal.blade.php
+++ b/src/resources/views/includes/reason-modal.blade.php
@@ -1,8 +1,8 @@
-<div class="modal fade" tabindex="-1" role="dialog" id="srp-ping">
+<div class="modal fade" tabindex="-1" role="dialog" id="srp-reason">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-            <h4 class="modal-title">Ping Information</h4>
+                <h4 class="modal-title">Reason</h4>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -42,7 +42,7 @@
                       </button>
                       @endif
                   </td>
-                  <td><a class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</a></td>
+                  <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
                   <td>{{ $kill->ship_type }}</td>
                   <td>
                       <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">
@@ -99,7 +99,7 @@
                       </button>
                       @endif
                   </td>
-                  <td><span rel='id-to-name'>{{ $kill->character_name }}</span></td>
+                  <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
                   <td>{{ $kill->ship_type }}</td>
                   <td>
                       <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">
@@ -137,6 +137,7 @@
 @endpush
 
 @push('javascript')
+@include('web::includes.javascript.id-to-name')
 
 <script type="application/javascript">
 

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -50,13 +50,13 @@
                       </button>
                   </td>
                   @if ($kill->approved === 0)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-warning">Pending</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-warning">Pending</span></td>
                   @elseif ($kill->approved === -1)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-danger">Rejected</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-danger">Rejected</span></td>
                   @elseif ($kill->approved === 1)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-success">Approved</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-success">Approved</span></td>
                   @elseif ($kill->approved === 2)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-primary">Paid Out</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-primary">Paid Out</span></td>
                   @endif
                   <td data-order="{{ strtotime($kill->created_at) }}>
                       <span data-toggle="tooltip" data-placement="top" title="{{ $kill->created_at }}">{{ human_diff($kill->created_at) }}</span>
@@ -107,13 +107,13 @@
                       </button>
                   </td>
                   @if ($kill->approved === 0)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-warning">Pending</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-warning">Pending</span></td>
                   @elseif ($kill->approved === -1)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-danger">Rejected</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-danger">Rejected</span></td>
                   @elseif ($kill->approved === 1)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-success">Approved</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-success">Approved</span></td>
                   @elseif ($kill->approved === 2)
-                    <td id="id-{{ $kill->kill_id }}"><span class="label label-primary">Paid Out</span></td>
+                    <td id="id-{{ $kill->kill_id }}"><span class="badge badge-primary">Paid Out</span></td>
                   @endif
                   <td data-order="{{ strtotime($kill->created_at) }}>
                       <span data-toggle="tooltip" data-placement="top" title="{{ $kill->created_at }}">{{ human_diff($kill->created_at) }}</span>
@@ -245,13 +245,13 @@
           timeout: 5000
         }).done(function (data) {
           if (data.name === "Approve") {
-              $("#id-"+data.value).html('<span class="label label-success">Approved</span>');
+              $("#id-"+data.value).html('<span class="badge badge-success">Approved</span>');
           } else if (data.name === "Reject") {
-              $("#id-"+data.value).html('<span class="label label-danger">Rejected</span>');
+              $("#id-"+data.value).html('<span class="badge badge-danger">Rejected</span>');
           } else if (data.name === "Paid Out") {
-              $("#id-"+data.value).html('<span class="label label-primary">Paid Out</span>');
+              $("#id-"+data.value).html('<span class="badge badge-primary">Paid Out</span>');
           } else if (data.name === "Pending") {
-              $("#id-"+data.value).html('<span class="label label-warning">Pending</span>');
+              $("#id-"+data.value).html('<span class="badge badge-warning">Pending</span>');
           }
           $("#approver-"+data.value).html(data.approver);
         });

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -3,6 +3,10 @@
 @section('title', trans('srp::srp.list'))
 @section('page_header', trans('srp::srp.list'))
 
+@push('head')
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests"> 
+@end
+
 @section('full')
     <div class="card card-primary card-solid">
         <div class="card-header">
@@ -27,6 +31,7 @@
                   <th>{{ trans('srp::srp.paidout') }}</th>
                   <th>{{ trans('srp::srp.submitted') }}</th>
                   <th>{{ trans('srp::srp.action') }}</th>
+                  <th>{{ trans('srp::srp.notes') }}</th>
                   <th>{{ trans('srp::srp.changedby') }}</th>
                 </tr>
             </thead>
@@ -66,6 +71,14 @@
                       <button type="button" class="btn btn-xs btn-danger srp-status" id="srp-status" name="{{ $kill->kill_id }}">Reject</button>
                       <button type="button" class="btn btn-xs btn-success srp-status" id="srp-status" name="{{ $kill->kill_id }}">Approve</button>
                       <button type="button" class="btn btn-xs btn-primary srp-status" id="srp-status" name="{{ $kill->kill_id }}">Paid Out</button>
+                  </td>                 
+                  <td>
+                      <button class="btn btn-xs btn-link" data-toggle="modal" data-target="#srp-reason" data-kill-id="{{ $kill->kill_id }}">
+                          <i class="fa fa-comment"></i>
+                      </button>
+                      <button class="btn btn-xs btn-link" data-toggle="modal" data-target="#srp-reason-edit" data-kill-id="{{ $kill->kill_id }}">
+                          <i class="fas fa-pencil-alt"></i>
+                      </button>
                   </td>
                   <td id="approver-{{ $kill->kill_id }}">{{ $kill->approver }}</td>
                 </tr>
@@ -84,6 +97,7 @@
                   <th>{{ trans('srp::srp.costs') }}</th>
                   <th>{{ trans('srp::srp.paidout') }}</th>
                   <th>{{ trans('srp::srp.submitted') }}</th>
+                  <th>{{ trans('srp::srp.notes') }}</th>
                   <th>{{ trans('srp::srp.changedby') }}</th>
                 </tr>
             </thead>
@@ -118,6 +132,11 @@
                   <td data-order="{{ strtotime($kill->created_at) }}>
                       <span data-toggle="tooltip" data-placement="top" title="{{ $kill->created_at }}">{{ human_diff($kill->created_at) }}</span>
                   </td>
+                  <td>
+                      <button class="btn btn-xs btn-link" data-toggle="modal" data-target="#srp-reason" data-kill-id="{{ $kill->kill_id }}">
+                          <i class="fa fa-comment"></i>
+                      </button>
+                  </td>
                   <td id="approver-{{ $kill->kill_id }}">{{ $kill->approver }}</td>
                 </tr>
                 @endif
@@ -130,6 +149,8 @@
     </div>
     @include('srp::includes.insurances-modal')
     @include('srp::includes.ping-modal')
+    @include('srp::includes.reason-edit-modal')
+    @include('srp::includes.reason-modal')
 @stop
 
 @push('head')
@@ -138,6 +159,12 @@
 
 @push('javascript')
 @include('web::includes.javascript.id-to-name')
+
+<script>
+    $(document).ready(function(){
+    $('[data-toggle="tooltip"]').tooltip();
+    });
+</script>
 
 <script type="application/javascript">
 
@@ -164,6 +191,36 @@
         });
 
         $(this).find('.overlay').hide();
+    });
+
+    $('#srp-reason').on('show.bs.modal', function(e){
+                var link = '{{ route('srp.reason', 0) }}';
+
+                $(this).find('.overlay').show();
+                $(this).find('.modal-body>p').text('');
+
+                $.ajax({
+                    url: link.replace('/0', '/' + $(e.relatedTarget).attr('data-kill-id')),
+                    dataType: 'json',
+                    method: 'GET'
+                }).done(function(response){
+                    $('#srp-reason').find('.modal-body>p').text(response.note).removeClass('text-danger');
+                }).fail(function(jqXHR, status){
+                    $('#srp-reason').find('.modal-body>p').text(status).addClass('text-danger');
+
+                    if (jqXHR.statusCode() !== 500)
+                        $('#srp-reason').find('.modal-body>p').text(jqXHR.responseJSON.msg);
+                });
+
+                $(this).find('.overlay').hide();
+            });
+
+
+    $('#srp-reason-edit').on('show.bs.modal', function(e){
+        var link = '{{ route('srp.reason', 0) }}';
+
+        $(this).find('#reasonContent').text('');
+        $(this).find('#srpKillId').val($(e.relatedTarget).attr('data-kill-id'));
     });
 
     $('#insurances').on('show.bs.modal', function(e){

--- a/src/resources/views/request.blade.php
+++ b/src/resources/views/request.blade.php
@@ -67,7 +67,7 @@
                             </button>
                             @endif
                         </td>
-                        <td><span rel='id-to-name'>{{ $kill->character_name }}</span></td>
+                        <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
                         <td>{{ $kill->ship_type }}</td>
                         <td>
                             <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">

--- a/src/resources/views/request.blade.php
+++ b/src/resources/views/request.blade.php
@@ -84,6 +84,11 @@
                             @elseif ($kill->approved === 2)
                                 <span class="badge badge-primary">Paid Out</span>
                             @endif
+                            @if(!is_null($kill->reason())) 
+                            <button class="btn btn-xs btn-link" data-toggle="modal" data-target="#srp-reason" data-kill-id="{{ $kill->kill_id }}">
+                                <i class="fa fa-comment"></i>
+                            </button>
+                            @endif
                         </td>
                         <td>
                             <span data-toggle="tooltip" data-placement="top" title="{{ $kill->created_at }}">{{ human_diff($kill->created_at) }}</span>
@@ -99,6 +104,7 @@
     </div>
     @include('srp::includes.insurances-modal')
     @include('srp::includes.ping-modal')
+    @include('srp::includes.reason-modal')
 @stop
 
 @section('right')
@@ -210,6 +216,28 @@
 
                     if (jqXHR.statusCode() !== 500)
                         $('#srp-ping').find('.modal-body>p').text(jqXHR.responseJSON.msg);
+                });
+
+                $(this).find('.overlay').hide();
+            });
+
+            $('#srp-reason').on('show.bs.modal', function(e){
+                var link = '{{ route('srp.reason', 0) }}';
+
+                $(this).find('.overlay').show();
+                $(this).find('.modal-body>p').text('');
+
+                $.ajax({
+                    url: link.replace('/0', '/' + $(e.relatedTarget).attr('data-kill-id')),
+                    dataType: 'json',
+                    method: 'GET'
+                }).done(function(response){
+                    $('#srp-reason').find('.modal-body>p').text(response.note).removeClass('text-danger');
+                }).fail(function(jqXHR, status){
+                    $('#srp-reason').find('.modal-body>p').text(status).addClass('text-danger');
+
+                    if (jqXHR.statusCode() !== 500)
+                        $('#srp-reason').find('.modal-body>p').text(jqXHR.responseJSON.msg);
                 });
 
                 $(this).find('.overlay').hide();

--- a/src/resources/views/request.blade.php
+++ b/src/resources/views/request.blade.php
@@ -76,13 +76,13 @@
                         </td>
                         <td>
                             @if ($kill->approved === 0)
-                                <span class="label label-warning">Pending</span>
+                                <span class="badge badge-warning">Pending</span>
                             @elseif ($kill->approved === -1)
-                                <span class="label label-danger">Rejected</span>
+                                <span class="badge badge-danger">Rejected</span>
                             @elseif ($kill->approved === 1)
-                                <span class="label label-success">Approved</span>
+                                <span class="badge badge-success">Approved</span>
                             @elseif ($kill->approved === 2)
-                                <span class="label label-primary">Paid Out</span>
+                                <span class="badge badge-primary">Paid Out</span>
                             @endif
                         </td>
                         <td>


### PR DESCRIPTION
- Admin Reason
    SRP Admins can now leave a reason note on any incomplete SRP claim. Closes #17 
- Character Name Resolution
    SRP claims where the victim is not registered in SeAT will now render the name of the character instead of the ID.
    Closes #13. Closes #37 
- Migration Fix
    Fixes a typo in the v3 to v4 migration that prevented users with any orphaned characters from completing the migration