### PR TITLE
Couple of fixes

### DIFF
--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -168,7 +168,7 @@ trait SrpManager
         if($deduct_insurance) {
             $ins = Insurance::where('type_id', $killmail->victim->ship_type_id)->where('Name', 'Platinum')->first();
             if(! is_null($ins)){
-                $total = $total + $ins->cost - $ins->refunded;
+                $total = $total + $ins->cost - $ins->payout;
             }
         }
 
@@ -239,7 +239,7 @@ trait SrpManager
         if($deduct_insurance) {
             $ins = Insurance::where('type_id', $killmail->victim->ship_type_id)->where('Name', 'Platinum')->first();
             if(! is_null($ins)){
-                $total = $total + $ins->cost - $ins->refunded;
+                $total = $total + $ins->cost - $ins->payout;
             }
         }
 

--- a/src/Http/Controllers/SrpAdminController.php
+++ b/src/Http/Controllers/SrpAdminController.php
@@ -12,6 +12,7 @@ use Denngarr\Seat\SeatSrp\Validation\ValidateRule;
 use Denngarr\Seat\SeatSrp\Validation\ValidateSettings;
 use Seat\Eveapi\Models\Sde\InvGroup;
 use Seat\Eveapi\Models\Sde\InvType;
+use \Seat\Eveapi\Models\Killmails\Killmail as EveKillmail;
 use Seat\Web\Http\Controllers\Controller;
 
 class SrpAdminController extends Controller
@@ -173,5 +174,14 @@ class SrpAdminController extends Controller
         logger()->info('Deleted ' . $deleted . ' killmails from SRP table');
 
         return json_encode(['deleted' => $deleted]);
+    }
+
+    /**
+     * @param \Seat\Eveapi\Models\Killmails\Killmail $killmail
+     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function showKillmailDetail(EveKillmail $killmail)
+    {
+        return view('web::common.killmails.modals.show.content', compact('killmail'));
     }
 }

--- a/src/Http/Controllers/SrpAdminController.php
+++ b/src/Http/Controllers/SrpAdminController.php
@@ -98,18 +98,21 @@ class SrpAdminController extends Controller
 
         // logger()->error($request->rule_type);
 
-        $e = AdvRule::where('type_id', $request->type_id)
-            ->where('rule_type', $request->rule_type)
-            ->get();
-        if ($e->count() > 0) { // Only an issue for now. In future want to update existing
-            // We are updating an exisiting row
-            return response()->json(['message' => 'Entry already exists for this type'], 400);
-        }
+        // $e = AdvRule::where('type_id', $request->type_id)
+        //     ->where('rule_type', $request->rule_type)
+        //     ->get();
+        // if ($e->count() > 0) { // Only an issue for now. In future want to update existing
+        //     // We are updating an exisiting row
+        //     return response()->json(['message' => 'Entry already exists for this type'], 400);
+        // }
 
         $rule = AdvRule::updateOrCreate([
             'rule_type' => $request->rule_type,
             'type_id' => $request->type_id,
             'group_id' => $request->group_id,
+        ]);
+
+        $rule->update([
             'price_source' => $request->source,
             'base_value' => $request->base_value,
             'hull_percent' => $request->hull_percent,
@@ -117,6 +120,8 @@ class SrpAdminController extends Controller
             'fit_percent' => $request->fit_percent,
             'deduct_insurance' => $request->deduct_insurance,
         ]);
+
+        $rule->save();
 
         return response('Added/Updated Type Rule', 200);
     }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -116,6 +116,12 @@ Route::group([
             'middleware' => 'can:srp.request',
         ]);
 
+        Route::get('/details/{killmail}', [
+            'as' => 'srp.killmaildetail',
+            'uses' => 'SrpAdminController@showKillmailDetail',
+            'middleware' => 'can:srp.settle',
+        ]);
+
         Route::get('/about', [
             'as'   => 'srp.about',
             'uses' => 'SrpController@getAboutView',

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -152,6 +152,12 @@ Route::group([
             'middleware' => 'can:srp.settings',
         ]);
 
+        Route::get('/settings/processmissing', [
+            'as'   => 'srp.missings',
+            'uses' => 'SrpAdminController@runMissingSearch',
+            'middleware' => 'can:srp.settings',
+        ]);
+
         Route::post('/settings', [
             'as'   => 'srp.savesettings',
             'uses' => 'SrpAdminController@saveSrpSettings',

--- a/src/Models/KillMail.php
+++ b/src/Models/KillMail.php
@@ -11,6 +11,7 @@ use Denngarr\Seat\SeatSrp\Models\Sde\InvType;
 use Denngarr\Seat\SeatSrp\Notifications\SrpRequestSubmitted;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
+use Seat\Eveapi\Models\Killmails\Killmail as EveKillmail;
 use Seat\Services\Models\Note;
 use Seat\Services\Traits\NotableTrait;
 use Seat\Web\Models\User;
@@ -66,5 +67,10 @@ class KillMail extends Model
             ->where('object_id', $this->kill_id)
             ->where('title', 'reason')
             ->first();
+    }
+
+    public function details()
+    {
+        return $this->hasOne(EveKillmail::class, 'killmail_id', 'kill_id');
     }
 }

--- a/src/Models/KillMail.php
+++ b/src/Models/KillMail.php
@@ -35,7 +35,7 @@ class KillMail extends Model
         parent::boot();
 
         self::created(function ($model) {
-            if(setting('webhook_url', true) != ''){
+            if(setting('denngarr_seat_srp_webhook_url', true) != ''){
                 $model->notify(new SrpRequestSubmitted());
             }
         });

--- a/src/Models/KillMail.php
+++ b/src/Models/KillMail.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Seat\Services\Models\Note;
 use Seat\Services\Traits\NotableTrait;
+use Seat\Web\Models\User;
 
 class KillMail extends Model
 {
@@ -39,6 +40,11 @@ class KillMail extends Model
                 $model->notify(new SrpRequestSubmitted());
             }
         });
+    }
+
+    public function user()
+    {
+        return $this->hasOne(User::class, 'id', 'user_id');
     }
 
     public function type()

--- a/src/Notifications/Webhooks/Discord.php
+++ b/src/Notifications/Webhooks/Discord.php
@@ -12,7 +12,7 @@ class Discord
         if(! $url){
             return [500, 'SRP DISCORD WEBHOOK URL is not defined in SRP Settings'];
         }
-        $srp_role_mention = setting('mention_role', true);
+        $srp_role_mention = setting('denngarr_seat_srp_mention_role', true);
         $headers = [
             'headers' => ['Content-Type' => 'application/json'],
             'json' => [

--- a/src/lang/en/srp.php
+++ b/src/lang/en/srp.php
@@ -9,6 +9,7 @@ return [
     'request' => 'Request SRP',
     'id' => 'ID',
     'submitted' => 'Submitted',
+    'submittedby' => 'Submitted By',
     'changedby' => 'Changed By',
     'approvedby' => 'Approved By',
     'notes' => 'Notes',

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -106,6 +106,7 @@
                 <tr>
                   <th>{{ trans('srp::srp.id') }}</th>
                   <th>{{ trans('srp::srp.characterName') }}</th>
+                  <th>{{ trans('srp::srp.submittedby') }}</th>
                   <th>{{ trans('srp::srp.shipType') }}</th>
                   <th>{{ trans('srp::srp.costs') }}</th>
                   <th>{{ trans('srp::srp.paidout') }}</th>
@@ -127,6 +128,7 @@
                       @endif
                   </td>
                   <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
+                  <td>{{$kill->user->name}}</td>
                   <td>{{ $kill->ship_type }}</td>
                   <td>
                       <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -30,6 +30,7 @@
                 <tr>
                   <th>{{ trans('srp::srp.id') }}</th>
                   <th>{{ trans('srp::srp.characterName') }}</th>
+                  <th>{{ trans('srp::srp.submittedby') }}</th>
                   <th>{{ trans('srp::srp.shipType') }}</th>
                   <th>{{ trans('srp::srp.costs') }}</th>
                   <th>{{ trans('srp::srp.paidout') }}</th>
@@ -52,6 +53,7 @@
                       @endif
                   </td>
                   <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
+                  <td>{{$kill->user->name}}</td>
                   <td>{{ $kill->ship_type }}</td>
                   <td>
                       <button type="button" class="btn btn-xs btn-link" data-toggle="modal" data-target="#insurances" data-kill-id="{{ $kill->kill_id }}">

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -51,6 +51,14 @@
                           <i class="fa fa-comment"></i>
                       </button>
                       @endif
+
+                      <!-- This is to open the killmail details modal -->
+                      <button data-toggle="modal" data-target="#killmail-detail"
+                        data-url="{{ route('srp.killmaildetail', ['killmail' => $kill]) }}"
+                        class="btn btn-sm btn-link">
+                        <i class="fas fa-eye"></i>
+                      </button>
+
                   </td>
                   <td><span class='id-to-name' data-id="{{ $kill->character_name }}">{{ $kill->character_name }}</span></td>
                   <td>{{$kill->user->name}}</td>
@@ -172,6 +180,7 @@
     @include('srp::includes.ping-modal')
     @include('srp::includes.reason-edit-modal')
     @include('srp::includes.reason-modal')
+    @include('web::common.killmails.modals.show.show')
     <div class="card-footer text-muted">
         Plugin maintained by <a href="{{ route('srp.about') }}"> {!! img('characters', 'portrait', 96057938, 64, ['class' => 'img-circle eve-icon small-icon']) !!} Crypta Electrica</a>. <span class="float-right snoopy" style="color: #fa3333;"><i class="fas fa-signal"></i></span>
     </div>

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -168,7 +168,7 @@
 
                                 <div class="form-group col-md">
                                     <label for="type_add">Submit</label>
-                                    <button type="button" data-placement="top" class="btn btn-primary form-control" id="type_add">Add</button>
+                                    <button type="button" data-placement="top" class="btn btn-primary form-control" id="type_add">Add / Update</button>
                                 </div>
 
 
@@ -276,7 +276,7 @@
 
                                 <div class="form-group col-md">
                                     <label for="group_add">Submit</label>
-                                    <button type="button" data-placement="top" class="btn btn-primary form-control" id="group_add">Add</button>
+                                    <button type="button" data-placement="top" class="btn btn-primary form-control" id="group_add">Add / Update</button>
                                 </div>
 
 

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -59,6 +59,10 @@
                             <label for="srp_delete" class="col-sm-3 col-form-label">Process Pending Deletions</label>
                             <input id="srp_delete" class="btn btn-danger float-right" value="DELETE!">
                         </div>
+                        <div class="form-group row">
+                            <label for="srp_missing" class="col-sm-3 col-form-label">Process Missing Killmail Details</label>
+                            <input id="srp_missing" class="btn btn-danger float-right" value="Search!">
+                        </div>
                     </div>
                     <div class="card-footer">
                         <input class="btn btn-success float-right" type="submit" value="Update">
@@ -620,6 +624,26 @@
                 $('#srp_delete').removeClass("btn-warning");
                 $('#srp_delete').addClass("btn-danger");
                 $('#srp_delete').prop('value', "Failed Deletion, check your logs");
+            }
+        })
+    });
+
+    $('#srp_missing').on('click', function() {
+        $.ajax({
+            type: "GET",
+            url: "{{ route('srp.missings') }}",
+            success: function(data) {
+                $('#srp_missing').removeClass("btn-danger");
+                $('#srp_missing').removeClass("btn-warning");
+                $('#srp_missing').addClass("btn-success");
+                $('#srp_missing').prop('value', 'Dispatched ' + JSON.parse(data).dispatched + ' killmails');
+                console.log(data);
+            },
+            error: function() {
+                $('#srp_missing').removeClass("btn-success");
+                $('#srp_missing').removeClass("btn-warning");
+                $('#srp_missing').addClass("btn-danger");
+                $('#srp_missing').prop('value', "Failed Search, check your logs");
             }
         })
     });


### PR DESCRIPTION
Adds in the user that has requested the SRP alongside the dead pilot name. closes #66 
Fixes a bug that prevents more than one group rule
Now allows advanced SRP rules to be updated instead of removed then readded.
Button added to allow fetching missing killmail details from legacy killmails.
Added ability to see locally stored killmail modal without needing to see killmail on zkillboard. Closes #65 