### PR TITLE
evepraisal.com setting Adjustment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "feibam/seat-srp",
+    "name": "denngarr/seat-srp",
     "description": "A module for SeAT that tracks SRP requests",
     "type": "seat-plugin",
     "license": "GPL-2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "denngarr/seat-srp",
+    "name": "feibam/seat-srp",
     "description": "A module for SeAT that tracks SRP requests",
     "type": "seat-plugin",
     "license": "GPL-2.0",

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -285,6 +285,8 @@ trait SrpManager
 
         $partsList = implode("\n", $priceList);
 
+        $evepraisal = setting('denngarr_seat_srp_evepraisal_endpoint', true);
+
         $response = (new Client())
             ->request('POST', "$evepraisal", [
                 'multipart' => [

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', 'https://aoeve.net/appraisal.json?market=jita', [
+            ->request('POST', 'https://evepraisal.absolute-order.com/appraisal.json?market=jita', [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', 'https://' + $_ENV["SRP_APPRAISE_SERVER_DOMAIN"]+'/appraisal.json?market=jita', [
+            ->request('POST', 'https://aoeve.net/appraisal.json?market=jita', [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', 'http://localhost:36618/appraisal.json?market=jita', [
+            ->request('POST', 'http://evepraisal-absolute-order-com/appraisal.json?market=jita', [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', 'http://evepraisal.com/appraisal.json?market=jita', [
+            ->request('POST', 'https://' + $_ENV["SRP_APPRAISE_SERVER_DOMAIN"]+'/appraisal.json?market=jita', [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -285,8 +285,10 @@ trait SrpManager
 
         $partsList = implode("\n", $priceList);
 
+        $evepraisal = setting('denngarr_seat_srp_evepraisal_domain', true);
+
         $response = (new Client())
-            ->request('POST', 'http://evepraisal-absolute-order-com/appraisal.json?market=jita', [
+            ->request('POST', "$evepraisal/appraisal.json?market=jita", [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', 'https://evepraisal.absolute-order.com/appraisal.json?market=jita', [
+            ->request('POST', 'http://localhost:36618/appraisal.json?market=jita', [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -286,7 +286,7 @@ trait SrpManager
         $partsList = implode("\n", $priceList);
 
         $response = (new Client())
-            ->request('POST', "$evepraisal/appraisal.json?market=jita", [
+            ->request('POST', "$evepraisal", [
                 'multipart' => [
                     [
                         'name' => 'uploadappraisal',

--- a/src/Http/Controllers/SrpAdminController.php
+++ b/src/Http/Controllers/SrpAdminController.php
@@ -92,6 +92,7 @@ class SrpAdminController extends Controller
         setting(['denngarr_seat_srp_webhook_url', $request->webhook_url], true);
         setting(['denngarr_seat_srp_mention_role', $request->mention_role], true);
         setting(['denngarr_seat_srp_advanced_srp', $request->srp_method], true);
+        setting(['denngarr_seat_srp_evepraisal_endpoint', $request->evepraisal], true);
 
         return redirect()->back()->with('success', 'SRP Settings have successfully been updated.');
     }

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -30,7 +30,7 @@
                         </div>
                         <h4>EvePraisal Config</h4>
                         <div class="form-group row">
-                            <label for="evepraisal" class="col-sm-3 col-form-label">EvePraisal Domain</label>
+                            <label for="evepraisal" class="col-sm-3 col-form-label">EvePraisal Endpoint</label>
                             <div class="col-sm-8">
                                 <div class="input-group col-sm">
                                     <input class="form-control" type="text" name="evepraisal" id="evepraisal" size="32" value="{{ setting('denngarr_seat_srp_evepraisal_domain', true) }}" />

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -33,9 +33,9 @@
                             <label for="evepraisal" class="col-sm-3 col-form-label">EvePraisal Endpoint</label>
                             <div class="col-sm-8">
                                 <div class="input-group col-sm">
-                                    <input class="form-control" type="text" name="evepraisal" id="evepraisal" size="32" value="{{ setting('denngarr_seat_srp_evepraisal_domain', true) }}" />
+                                    <input class="form-control" type="text" name="evepraisal" id="evepraisal" size="32" value="{{ setting('denngarr_seat_srp_evepraisal_endpoint', true) }}" />
                                 </div>
-                                <small class="text-muted ml-2">Enter the Endpoint to an evepraisal instance like https (http)://evepraisal.com/appraisal.json?market=jita</small>
+                                <small class="text-muted ml-2">Enter the Endpoint to an evepraisal instance like https or (http)://evepraisal.com/appraisal.json?market=jita</small>
                             </div>
                         </div>
                         <div class="form-group row">

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -35,7 +35,7 @@
                                 <div class="input-group col-sm">
                                     <input class="form-control" type="text" name="evepraisal" id="evepraisal" size="32" value="{{ setting('denngarr_seat_srp_evepraisal_domain', true) }}" />
                                 </div>
-                                <small class="text-muted ml-2">Enter the domain to an evepraisal instance like www.goonpraisal.com</small>
+                                <small class="text-muted ml-2">Enter the Endpoint to an evepraisal instance like https (http)://evepraisal.com/appraisal.json?market=jita</small>
                             </div>
                         </div>
                         <div class="form-group row">

--- a/src/resources/views/settings.blade.php
+++ b/src/resources/views/settings.blade.php
@@ -18,7 +18,7 @@
                 </div>
                 <form method="POST" action="{{ route('srp.savesettings')  }}" class="form-horizontal">
                     <div class="card-body">
-                        {{ csrf_field() }}
+                        @csrf
                         <h4>Webhook Config</h4>
                         <div class="form-group row">
                             <label for="webhook_url" class="col-sm-3 col-form-label">Webhook URL</label>
@@ -26,6 +26,16 @@
                                 <div class="input-group col-sm">
                                     <input class="form-control" type="text" name="webhook_url" id="webhook_url" size="32" value="{{ setting('denngarr_seat_srp_webhook_url', true) }}" />
                                 </div>
+                            </div>
+                        </div>
+                        <h4>EvePraisal Config</h4>
+                        <div class="form-group row">
+                            <label for="evepraisal" class="col-sm-3 col-form-label">EvePraisal Domain</label>
+                            <div class="col-sm-8">
+                                <div class="input-group col-sm">
+                                    <input class="form-control" type="text" name="evepraisal" id="evepraisal" size="32" value="{{ setting('denngarr_seat_srp_evepraisal_domain', true) }}" />
+                                </div>
+                                <small class="text-muted ml-2">Enter the domain to an evepraisal instance like www.goonpraisal.com</small>
                             </div>
                         </div>
                         <div class="form-group row">


### PR DESCRIPTION
I recommend letting the user provide the complete endpoint
Instead of forcing users to only modify the domain name and force the use of https
Because when seat and evepraisal instances are run under docker
It is a LAN so no need for http
Or the user uses a modified evepraisal and its endpoint has been changed.